### PR TITLE
Use Composer to install WP-CLI in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ cache:
 
 env:
   global:
-    - WP_CLI_BIN_DIR=/tmp/wp-cli-phar
+    - PATH="$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
+    - WP_CLI_BIN_DIR="$TRAVIS_BUILD_DIR/vendor/bin"
 
 matrix:
   include:
@@ -32,9 +33,15 @@ matrix:
     - php: 5.3
       env: WP_VERSION=latest
 
-before_script:
+before_install:
   - phpenv config-rm xdebug.ini
-  - composer validate
+
+install:
+  - composer install
   - bash bin/install-package-tests.sh
 
-script: ./vendor/bin/behat --format progress --strict
+before_script:
+  - composer validate
+
+script:
+  - behat --format progress --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ before_script:
   - composer validate
 
 script:
-  - behat --format progress --strict
+  - ./bin/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ env:
 
 matrix:
   include:
-    - php: 7.1
+    - php: 7.1.0
       env: WP_VERSION=latest
-    - php: 7.0
+    - php: 7.0.15
       env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ env:
 
 matrix:
   include:
-    - php: 7.1.0
+    - php: 7.1
       env: WP_VERSION=latest
-    - php: 7.0.15
+    - php: 7.0
       env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=latest

--- a/bin/install-package-tests.sh
+++ b/bin/install-package-tests.sh
@@ -2,39 +2,9 @@
 
 set -ex
 
-WP_CLI_BIN_DIR=${WP_CLI_BIN_DIR-/tmp/wp-cli-phar}
-
-PACKAGE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
-
-download() {
-    if [ `which curl` ]; then
-        curl -s "$1" > "$2";
-    elif [ `which wget` ]; then
-        wget -nv -O "$2" "$1"
-    fi
-}
-
-install_wp_cli() {
-
-	# the Behat test suite will pick up the executable found in $WP_CLI_BIN_DIR
-	mkdir -p $WP_CLI_BIN_DIR
-	download https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar $WP_CLI_BIN_DIR/wp
-	chmod +x $WP_CLI_BIN_DIR/wp
-
-}
-
-download_behat() {
-
-	cd $PACKAGE_DIR
-	composer require --dev behat/behat='~2.5'
-
-}
-
 install_db() {
 	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot
 	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 }
 
-install_wp_cli
-download_behat
 install_db

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+
+BEHAT_TAGS=$(php utils/behat-tags.php)
+
+# Run the functional tests
+behat --format progress $BEHAT_TAGS --strict
+

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -2,8 +2,7 @@
 
 set -ex
 
-BEHAT_TAGS=$(php utils/behat-tags.php)
-
 # Run the functional tests
+BEHAT_TAGS=$(php utils/behat-tags.php)
 behat --format progress $BEHAT_TAGS --strict
 

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,16 @@
         "psr-4": {"": "src/"},
         "files": [ "import-command.php" ]
     },
-    "require": {},
+    "require": {
+        "wp-cli/wp-cli": "dev-master"
+    },
     "require-dev": {
         "behat/behat": "~2.5"
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        },
         "commands": [
             "import"
         ]

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.x-dev"
         },
         "commands": [
             "import"

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {"": "src/"},
         "files": [ "import-command.php" ]

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -318,7 +318,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 	public function create_config( $subdir = '' ) {
 		$params = self::$db_settings;
-		$params['dbprefix'] = $subdir ?: 'wp_';
+		// Replaces all characters that are not alphanumeric or an underscore into an underscore.
+		$params['dbprefix'] = $subdir ? preg_replace( '#[^a-zA-Z\_0-9]#', '_', $subdir ) : 'wp_';
 
 		$params['skip-salts'] = true;
 		$this->proc( 'wp core config', $params, $subdir )->run_check();

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -823,3 +823,16 @@ function parse_str_to_argv( $arguments ) {
 	}, $argv );
 	return $argv;
 }
+
+/**
+ * Locale-independent version of basename()
+ *
+ * @access public
+ *
+ * @param string $path
+ * @param string $suffix
+ * @return string
+ */
+function basename( $path, $suffix = '' ) {
+	return urldecode( \basename( str_replace( array( '%2F', '%5C' ), '/', urlencode( $path ) ), $suffix ) );
+}

--- a/import-command.php
+++ b/import-command.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 }
 
 $autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
+if ( file_exists( $autoload ) && ! class_exists( 'Import_Command' ) ) {
 	require_once $autoload;
 }
 

--- a/import-command.php
+++ b/import-command.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 }
 
 $autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) && ! class_exists( 'Import_Command' ) ) {
+if ( file_exists( $autoload ) ) {
 	require_once $autoload;
 }
 

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Generate a list of tags to skip during the test run.
+ *
+ * Require a minimum version of WordPress:
+ *
+ *   @require-wp-4.0
+ *   Scenario: Core translation CRUD
+ *
+ * Then use in bash script:
+ *
+ *   BEHAT_TAGS=$(php behat-tags.php)
+ *   vendor/bin/behat --format progress $BEHAT_TAGS
+ */
+
+function version_tags( $prefix, $current, $operator = '<' ) {
+	if ( ! $current )
+		return array();
+
+	exec( "grep '@{$prefix}-[0-9\.]*' -h -o features/*.feature | uniq", $existing_tags );
+
+	$skip_tags = array();
+
+	foreach ( $existing_tags as $tag ) {
+		$compare = str_replace( "@{$prefix}-", '', $tag );
+		if ( version_compare( $current, $compare, $operator ) ) {
+			$skip_tags[] = $tag;
+		}
+	}
+
+	return $skip_tags;
+}
+
+$skip_tags = array_merge(
+	version_tags( 'require-wp', getenv( 'WP_VERSION' ), '<' ),
+	version_tags( 'require-php', PHP_VERSION, '<' ),
+	version_tags( 'less-than-php', PHP_VERSION, '>' )
+);
+
+# Skip Github API tests by default because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
+$skip_tags[] = '@github-api';
+
+if ( !empty( $skip_tags ) ) {
+	echo '--tags=~' . implode( '&&~', $skip_tags );
+}
+


### PR DESCRIPTION
Doing so ensures tests run against local copy of command, instead of
Phar bundled version.

See https://github.com/wp-cli/wp-cli/issues/3850#issuecomment-288719442