### PR TITLE
Prevents non-existent directories from ending up in list of files to import

### DIFF
--- a/src/Import_Command.php
+++ b/src/Import_Command.php
@@ -58,7 +58,9 @@ class Import_Command extends WP_CLI_Command {
 				$files = glob( rtrim( $arg, '/' ) . '/*.{wxr,xml}', GLOB_BRACE );
 				$new_args = array_merge( $new_args, $files );
 			} else {
-				$new_args[] = $arg;
+				if ( file_exists( $arg ) ) {
+					$new_args[] = $arg;
+				}
 			}
 		}
 		$args = $new_args;


### PR DESCRIPTION
Discovered that if you type a directory to import incorrectly, is_dir will return false but the incorrect directory will end up in the new_args array of files to import. This adds an additional condition to ensure the file exists.