### PR TITLE
Avoid use of GLOB_BRACE for compat with Alpine Linux.

### DIFF
--- a/features/import.feature
+++ b/features/import.feature
@@ -123,7 +123,7 @@ Feature: Import content.
 
     When I run `wp import export --authors=skip --skip=image_resize`
     Then STDOUT should not be empty
-	And STDERR should be empty
+    And STDERR should be empty
 
     When I run `wp post list --post_type=post,page --format=count`
     Then STDOUT should be:

--- a/features/import.feature
+++ b/features/import.feature
@@ -88,6 +88,49 @@ Feature: Import content.
       100
       """
 
+  Scenario: Export and import a directory of files with .wxr and .xml extensions.
+    Given a WP install
+    And I run `mkdir export`
+
+    When I run `wp post list --post_type=post,page --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp export --dir=export --post_type=post --filename_format={site}.wordpress.{date}.{n}.xml`
+    Then STDOUT should not be empty
+    When I run `wp export --dir=export --post_type=page --filename_format={site}.wordpress.{date}.{n}.wxr`
+    Then STDOUT should not be empty
+
+    When I run `wp site empty --yes`
+    Then STDOUT should not be empty
+
+    When I run `wp post list --post_type=post,page --format=count`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `find export -type f | wc -l`
+    Then STDOUT should contain:
+      """
+      2
+      """
+
+    When I run `wp plugin install wordpress-importer --activate`
+    Then STDERR should be empty
+
+    When I run `wp import export --authors=skip --skip=image_resize`
+    Then STDOUT should not be empty
+	And STDERR should be empty
+
+    When I run `wp post list --post_type=post,page --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
   @less-than-php-7 @require-wp-4.0
   Scenario: Export and import page and referencing menu item
   # This will not work with WP 3.7.11 or PHP 7.

--- a/src/Import_Command.php
+++ b/src/Import_Command.php
@@ -55,8 +55,13 @@ class Import_Command extends WP_CLI_Command {
 		$new_args = array();
 		foreach( $args as $arg ) {
 			if ( is_dir( $arg ) ) {
-				$files = glob( rtrim( $arg, '/' ) . '/*.{wxr,xml}', GLOB_BRACE );
-				$new_args = array_merge( $new_args, $files );
+				$dir = WP_CLI\Utils\trailingslashit( $arg );
+				if ( ( $files = glob( $dir . '*.wxr' ) ) ) {
+					$new_args = array_merge( $new_args, $files );
+				}
+				if ( ( $files = glob( $dir . '*.xml' ) ) ) {
+					$new_args = array_merge( $new_args, $files );
+				}
 			} else {
 				if ( file_exists( $arg ) ) {
 					$new_args[] = $arg;


### PR DESCRIPTION
Issue https://github.com/wp-cli/wp-cli/issues/4353

Avoids the use of `GLOB_BRACE` for `glob()` of `*.wxr` and `*.xml` by breaking it in two, for compatibility with Alpine Linux.