### PR TITLE
Add support for Probot `move` command

### DIFF
--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,0 +1,19 @@
+# Configuration for move-issues - https://github.com/dessant/move-issues
+
+# Repository to extend settings from
+_extends: wp-cli/wp-cli
+
+# Delete the command comment when it contains no other content
+# deleteCommand: true
+
+# Close the source issue after moving
+# closeSourceIssue: true
+
+# Lock the source issue after moving
+# lockSourceIssue: false
+
+# Mention issue and comment authors
+# mentionAuthors: true
+
+# Preserve mentions in the issue content
+# keepContentMentions: true


### PR DESCRIPTION
Extends the configuration submitted via https://github.com/wp-cli/wp-cli/pull/4980 .

See https://probot.github.io/apps/move/ for documentation.