### PR TITLE
PHPCS: fix up the code base [1] - whitespace & inline control structures

### DIFF
--- a/src/Import_Command.php
+++ b/src/Import_Command.php
@@ -33,7 +33,7 @@ class Import_Command extends WP_CLI_Command {
 	 *     Success: Finished importing from 'example.wordpress.2016-06-21.xml' file.
 	 */
 	public function __invoke( $args, $assoc_args ) {
-		$defaults = array(
+		$defaults   = array(
 			'authors' => null,
 			'skip'    => array(),
 		);
@@ -53,7 +53,7 @@ class Import_Command extends WP_CLI_Command {
 		WP_CLI::log( 'Starting the import process...' );
 
 		$new_args = array();
-		foreach( $args as $arg ) {
+		foreach ( $args as $arg ) {
 			if ( is_dir( $arg ) ) {
 				$dir = WP_CLI\Utils\trailingslashit( $arg );
 				if ( ( $files = glob( $dir . '*.wxr' ) ) ) {
@@ -80,7 +80,7 @@ class Import_Command extends WP_CLI_Command {
 			if ( is_wp_error( $ret ) ) {
 				WP_CLI::error( $ret );
 			} else {
-				WP_CLI::log(''); // WXR import ends with HTML, so make sure message is on next line
+				WP_CLI::log( '' ); // WXR import ends with HTML, so make sure message is on next line
 				WP_CLI::success( "Finished importing from '$file' file." );
 			}
 		}
@@ -91,11 +91,12 @@ class Import_Command extends WP_CLI_Command {
 	 */
 	private function import_wxr( $file, $args ) {
 
-		$wp_import = new WP_Import;
+		$wp_import                  = new WP_Import();
 		$wp_import->processed_posts = $this->processed_posts;
-		$import_data = $wp_import->parse( $file );
-		if ( is_wp_error( $import_data ) )
+		$import_data                = $wp_import->parse( $file );
+		if ( is_wp_error( $import_data ) ) {
 			return $import_data;
+		}
 
 		// Prepare the data to be used in process_author_mapping();
 		$wp_import->get_authors_from_import( $import_data );
@@ -106,55 +107,65 @@ class Import_Command extends WP_CLI_Command {
 
 		$author_data = array();
 		foreach ( $wp_import->authors as $wxr_author ) {
-			$author = new \stdClass;
+			$author = new \stdClass();
 			// Always in the WXR
 			$author->user_login = $wxr_author['author_login'];
 
 			// Should be in the WXR; no guarantees
-			if ( isset ( $wxr_author['author_email'] ) ) {
+			if ( isset( $wxr_author['author_email'] ) ) {
 				$author->user_email = $wxr_author['author_email'];
 			}
-			if ( isset( $wxr_author['author_display_name'] ) )
+			if ( isset( $wxr_author['author_display_name'] ) ) {
 				$author->display_name = $wxr_author['author_display_name'];
-			if ( isset( $wxr_author['author_first_name'] ) )
+			}
+			if ( isset( $wxr_author['author_first_name'] ) ) {
 				$author->first_name = $wxr_author['author_first_name'];
-			if ( isset( $wxr_author['author_last_name'] ) )
+			}
+			if ( isset( $wxr_author['author_last_name'] ) ) {
 				$author->last_name = $wxr_author['author_last_name'];
+			}
 
 			$author_data[] = $author;
 		}
 
 		// Build the author mapping
 		$author_mapping = $this->process_author_mapping( $args['authors'], $author_data );
-		if ( is_wp_error( $author_mapping ) )
+		if ( is_wp_error( $author_mapping ) ) {
 			return $author_mapping;
+		}
 
-		$author_in = wp_list_pluck( $author_mapping, 'old_user_login' );
+		$author_in  = wp_list_pluck( $author_mapping, 'old_user_login' );
 		$author_out = wp_list_pluck( $author_mapping, 'new_user_login' );
 		unset( $author_mapping, $author_data );
 
 		// $user_select needs to be an array of user IDs
-		$user_select = array();
+		$user_select         = array();
 		$invalid_user_select = array();
 		foreach ( $author_out as $author_login ) {
 			$user = get_user_by( 'login', $author_login );
-			if ( $user )
+			if ( $user ) {
 				$user_select[] = $user->ID;
-			else
+			} else {
 				$invalid_user_select[] = $author_login;
+			}
 		}
-		if ( ! empty( $invalid_user_select ) )
-			return new WP_Error( 'invalid-author-mapping', sprintf( "These user_logins are invalid: %s", implode( ',', $invalid_user_select ) ) );
+		if ( ! empty( $invalid_user_select ) ) {
+			return new WP_Error( 'invalid-author-mapping', sprintf( 'These user_logins are invalid: %s', implode( ',', $invalid_user_select ) ) );
+		}
 
 		unset( $author_out );
 
 		// Drive the import
-		$wp_import->fetch_attachments = !in_array( 'attachment', $args['skip'] );
-		$_GET = array( 'import' => 'wordpress', 'step' => 2 );
+		$wp_import->fetch_attachments = ! in_array( 'attachment', $args['skip'] );
+
+		$_GET  = array(
+			'import' => 'wordpress',
+			'step'   => 2,
+		);
 		$_POST = array(
-			'imported_authors'     => $author_in,
-			'user_map'             => $user_select,
-			'fetch_attachments'    => $wp_import->fetch_attachments,
+			'imported_authors'  => $author_in,
+			'user_map'          => $user_select,
+			'fetch_attachments' => $wp_import->fetch_attachments,
 		);
 
 		if ( in_array( 'image_resize', $args['skip'] ) ) {
@@ -181,14 +192,14 @@ class Import_Command extends WP_CLI_Command {
 		add_filter( 'wp_import_posts', function( $posts ) {
 			global $wpcli_import_counts;
 			$wpcli_import_counts['current_post'] = 0;
-			$wpcli_import_counts['total_posts'] = count( $posts );
+			$wpcli_import_counts['total_posts']  = count( $posts );
 			return $posts;
 		}, 10 );
 
 		add_filter( 'wp_import_post_comments', function( $comments, $post_id, $post ) {
 			global $wpcli_import_counts;
 			$wpcli_import_counts['current_comment'] = 0;
-			$wpcli_import_counts['total_comments'] = count( $comments );
+			$wpcli_import_counts['total_comments']  = count( $comments );
 			return $comments;
 		}, 10, 3 );
 
@@ -196,8 +207,8 @@ class Import_Command extends WP_CLI_Command {
 			global $wpcli_import_counts, $wp_cli_import_current_file;
 
 			$wpcli_import_counts['current_post']++;
-			WP_CLI::log('');
-			WP_CLI::log('');
+			WP_CLI::log( '' );
+			WP_CLI::log( '' );
 			WP_CLI::log( sprintf( 'Processing post #%d ("%s") (post_type: %s)', $post['post_id'], $post['post_title'], $post['post_type'] ) );
 			WP_CLI::log( sprintf( '-- %s of %s (in file %s)', number_format( $wpcli_import_counts['current_post'] ), number_format( $wpcli_import_counts['total_posts'] ), $wp_cli_import_current_file ) );
 			WP_CLI::log( '-- ' . date( 'r' ) );
@@ -208,14 +219,14 @@ class Import_Command extends WP_CLI_Command {
 		add_action( 'wp_import_insert_post', function( $post_id, $original_post_ID, $post, $postdata ) {
 			global $wpcli_import_counts;
 			if ( is_wp_error( $post_id ) ) {
-				WP_CLI::warning( "-- Error importing post: " . $post_id->get_error_code() );
+				WP_CLI::warning( '-- Error importing post: ' . $post_id->get_error_code() );
 			} else {
 				WP_CLI::log( "-- Imported post as post_id #{$post_id}" );
 			}
 
 			if ( $wpcli_import_counts['current_post'] % 500 === 0 ) {
 				WP_CLI\Utils\wp_clear_object_cache();
-				WP_CLI::log( "-- Cleared object cache." );
+				WP_CLI::log( '-- Cleared object cache.' );
 			}
 
 		}, 10, 4 );
@@ -225,7 +236,7 @@ class Import_Command extends WP_CLI_Command {
 		}, 10, 4 );
 
 		add_action( 'wp_import_set_post_terms', function( $tt_ids, $term_ids, $taxonomy, $post_id, $post ) {
-			WP_CLI::log( "-- Added terms (" . implode( ',', $term_ids ) .") for taxonomy \"{$taxonomy}\"" );
+			WP_CLI::log( '-- Added terms (' . implode( ',', $term_ids ) . ") for taxonomy \"{$taxonomy}\"" );
 		}, 10, 5 );
 
 		add_action( 'wp_import_insert_comment', function( $comment_id, $comment, $comment_post_ID, $post ) {
@@ -250,12 +261,13 @@ class Import_Command extends WP_CLI_Command {
 			return true;
 		}
 
-		$plugins = get_plugins();
+		$plugins            = get_plugins();
 		$wordpress_importer = 'wordpress-importer/wordpress-importer.php';
-		if ( array_key_exists( $wordpress_importer, $plugins ) )
+		if ( array_key_exists( $wordpress_importer, $plugins ) ) {
 			$error_msg = "WordPress Importer needs to be activated. Try 'wp plugin activate wordpress-importer'.";
-		else
+		} else {
 			$error_msg = "WordPress Importer needs to be installed. Try 'wp plugin install wordpress-importer --activate'.";
+		}
 
 		return new WP_Error( 'importer-missing', $error_msg );
 	}
@@ -270,14 +282,16 @@ class Import_Command extends WP_CLI_Command {
 	private function process_author_mapping( $authors_arg, $author_data ) {
 
 		// Provided an author mapping file (method checks validity)
-		if ( file_exists( $authors_arg ) )
+		if ( file_exists( $authors_arg ) ) {
 			return $this->read_author_mapping_file( $authors_arg );
+		}
 
 		// Provided a file reference, but the file doesn't yet exist
-		if ( false !== stripos( $authors_arg, '.csv' ) )
+		if ( false !== stripos( $authors_arg, '.csv' ) ) {
 			return $this->create_author_mapping_file( $authors_arg, $author_data );
+		}
 
-		switch( $authors_arg ) {
+		switch ( $authors_arg ) {
 			// Create authors if they don't yet exist; maybe match on email or user_login
 			case 'create':
 				return $this->create_authors_for_mapping( $author_data );
@@ -298,8 +312,9 @@ class Import_Command extends WP_CLI_Command {
 		$author_mapping = array();
 
 		foreach ( new \WP_CLI\Iterators\CSV( $file ) as $i => $author ) {
-			if ( ! array_key_exists( 'old_user_login', $author ) || ! array_key_exists( 'new_user_login', $author ) )
+			if ( ! array_key_exists( 'old_user_login', $author ) || ! array_key_exists( 'new_user_login', $author ) ) {
 				return new WP_Error( 'invalid-author-mapping', "Author mapping file isn't properly formatted." );
+			}
 
 			$author_mapping[] = $author;
 		}
@@ -324,7 +339,7 @@ class Import_Command extends WP_CLI_Command {
 			}
 			$file_resource = fopen( $file, 'w' );
 			\WP_CLI\utils\write_csv( $file_resource, $author_mapping, array( 'old_user_login', 'new_user_login' ) );
-			return new WP_Error( 'author-mapping-error', sprintf( "Please update author mapping file before continuing: %s", $file ) );
+			return new WP_Error( 'author-mapping-error', sprintf( 'Please update author mapping file before continuing: %s', $file ) );
 		} else {
 			return new WP_Error( 'author-mapping-error', "Couldn't create author mapping file." );
 		}
@@ -361,12 +376,14 @@ class Import_Command extends WP_CLI_Command {
 				'user_email' => '',
 				'user_pass'  => wp_generate_password(),
 			);
-			$user = array_merge( $user, (array)$author );
-			$user_id = wp_insert_user( $user );
-			if ( is_wp_error( $user_id ) )
-				return $user_id;
+			$user = array_merge( $user, (array) $author );
 
-			$user = get_user_by( 'id', $user_id );
+			$user_id = wp_insert_user( $user );
+			if ( is_wp_error( $user_id ) ) {
+				return $user_id;
+			}
+
+			$user             = get_user_by( 'id', $user_id );
 			$author_mapping[] = array(
 				'old_user_login' => $author->user_login,
 				'new_user_login' => $user->user_login,
@@ -381,30 +398,32 @@ class Import_Command extends WP_CLI_Command {
 	 */
 	private function suggest_user( $author_user_login, $author_user_email = '' ) {
 
-		if ( ! isset( $this->blog_users ) )
+		if ( ! isset( $this->blog_users ) ) {
 			$this->blog_users = get_users();
+		}
 
-		$shortest = -1;
+		$shortest    = -1;
 		$shortestavg = array();
 
 		$threshold = floor( ( strlen( $author_user_login ) / 100 ) * 10 ); // 10 % of the strlen are valid
-		$closest = '';
+		$closest   = '';
 		foreach ( $this->blog_users as $user ) {
 			// Before we resort to an algorithm, let's try for an exact match
-			if ( $author_user_email && $user->user_email == $author_user_email )
+			if ( $author_user_email && $user->user_email == $author_user_email ) {
 				return $user->user_login;
+			}
 
-			$levs = array();
-			$levs[] = levenshtein( $author_user_login, $user->display_name );
-			$levs[] = levenshtein( $author_user_login, $user->user_login );
-			$levs[] = levenshtein( $author_user_login, $user->user_email );
-			$email_parts = explode( "@", $user->user_email );
+			$levs        = array();
+			$levs[]      = levenshtein( $author_user_login, $user->display_name );
+			$levs[]      = levenshtein( $author_user_login, $user->user_login );
+			$levs[]      = levenshtein( $author_user_login, $user->user_email );
+			$email_parts = explode( '@', $user->user_email );
 			$email_login = array_shift( $email_parts );
-			$levs[] = levenshtein( $author_user_login, $email_login );
+			$levs[]      = levenshtein( $author_user_login, $email_login );
 			rsort( $levs );
 			$lev = array_pop( $levs );
 			if ( 0 == $lev ) {
-				$closest = $user->user_login;
+				$closest  = $user->user_login;
 				$shortest = 0;
 				break;
 			}
@@ -416,8 +435,10 @@ class Import_Command extends WP_CLI_Command {
 			$shortestavg[] = $lev;
 		}
 		// in case all usernames have a common pattern
-		if ( $shortest > ( array_sum( $shortestavg ) / count( $shortestavg ) ) )
+		if ( $shortest > ( array_sum( $shortestavg ) / count( $shortestavg ) ) ) {
 			return '';
+		}
+
 		return $closest;
 	}
 


### PR DESCRIPTION
Simple, mostly whitespace related, fixes to make the code comply with the WPCliCS rules.

Fixes relate to the following rules:
* No inline control structures (seriously ?).
* Align the equality operators in assignment blocks.
* One space between a control structure keyword and the open parenthesis.
* No space between a function call/language contruct keyword and the open parenthesis.
* One space on the inside of open/close parenthesis when there is content between them.
* Always use parenthesis when instantiating a new object.
* One space after the `!` operator.
* One space after type casts.
* One space before and after concatenation operators.
* Associative arrays with more than one item, should be multi-line.
* The double arrow in multi-line arrays should be aligned.
* Use single quoted strings when the string doesn't contain a single quote or variables.

