### PR TITLE
PHPCS: fix up the code base [2] - scope modifiers

### DIFF
--- a/src/Import_Command.php
+++ b/src/Import_Command.php
@@ -2,7 +2,7 @@
 
 class Import_Command extends WP_CLI_Command {
 
-	var $processed_posts = array();
+	public $processed_posts = array();
 
 	/**
 	 * Imports content from a given WXR file.


### PR DESCRIPTION
Fixes relate to the following rules:
* Always specify visibility for all class properties and methods.