### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor/
 *.tar.gz
 composer.lock
 *.log
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "wp-cli/entity-command": "^1.3 || ^2",
         "wp-cli/export-command": "^1 || ^2",
         "wp-cli/extension-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-import">
+	<description>Custom ruleset for WP-CLI import-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS">
+		<!-- The two instances which trigger this sniff in this project are example filenames in documentation. -->
+		<exclude name="WordPress.WP.CapitalPDangit" />
+	</rule>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\Import"/><!-- Namespaces. -->
+				<element value="wpcli_import"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/src/Import_Command\.php$</exclude-pattern>
+	</rule>
+
+</ruleset>


### PR DESCRIPTION
This basically adds a PHPCS ruleset using the new `WPCliCS`standard.

Please see the individual commits for more detail.

The build for this PR won't be able to pass until `wp-cli-tests` `2.1` has been released, upon which time, the build can just be restarted and should be green ;-)

Fixes #51 