### PR TITLE
Handle author_id when importing users

### DIFF
--- a/src/Import_Command.php
+++ b/src/Import_Command.php
@@ -115,6 +115,9 @@ class Import_Command extends WP_CLI_Command {
 			$author->user_login = $wxr_author['author_login'];
 
 			// Should be in the WXR; no guarantees
+			if ( isset( $wxr_author['author_id'] ) ) {
+				$author->ID = $wxr_author['author_id'];
+			}
 			if ( isset( $wxr_author['author_email'] ) ) {
 				$author->user_email = $wxr_author['author_email'];
 			}


### PR DESCRIPTION
Author ID is handled when by `wordpress-importer` (https://plugins.trac.wordpress.org/browser/wordpress-importer/trunk/parsers/class-wxr-parser-simplexml.php#L70), so it should be available in WP CLI, too.
