### PR TITLE
Bail with status code if file doesnt exits

### DIFF
--- a/src/Import_Command.php
+++ b/src/Import_Command.php
@@ -71,7 +71,6 @@ class Import_Command extends WP_CLI_Command {
 				}
 			}
 		}
-
 		$args = $new_args;
 
 		if ( empty( $args ) ) {

--- a/src/Import_Command.php
+++ b/src/Import_Command.php
@@ -65,22 +65,32 @@ class Import_Command extends WP_CLI_Command {
 				if ( ! empty( $files ) ) {
 					$new_args = array_merge( $new_args, $files );
 				}
-			} else {
-				if ( file_exists( $arg ) ) {
-					$new_args[] = $arg;
+
+				if ( empty( $files ) ) {
+					WP_CLI::warning( "No import files found in '$arg'." );
 				}
-			}
-		}
-		$args = $new_args;
+			} else {
+				if ( ! file_exists( $arg ) ) {
+					WP_CLI::warning( " '$arg' doesn't exist." );
+					continue;
+				}
 
-		if ( empty( $args ) ) {
-			WP_CLI::error( "Import file doesn't exists." );
-		}
+				if ( is_readable( $arg ) ) {
+					$new_args[] = $arg;
+					continue;
+				}
 
-		foreach ( $args as $file ) {
-			if ( ! is_readable( $file ) ) {
 				WP_CLI::warning( "Can't read '$file' file." );
 			}
+		}
+
+		if ( empty( $new_args ) ) {
+			WP_CLI::error( "Import failed due to missing or unreadable file/s." );
+		}
+
+		$args = $new_args;
+
+		foreach ( $args as $file ) {
 
 			$ret = $this->import_wxr( $file, $assoc_args );
 

--- a/src/Import_Command.php
+++ b/src/Import_Command.php
@@ -71,7 +71,12 @@ class Import_Command extends WP_CLI_Command {
 				}
 			}
 		}
+
 		$args = $new_args;
+
+		if ( empty( $args ) ) {
+			WP_CLI::error( "Import file doesn't exists." );
+		}
 
 		foreach ( $args as $file ) {
 			if ( ! is_readable( $file ) ) {

--- a/src/Import_Command.php
+++ b/src/Import_Command.php
@@ -67,7 +67,7 @@ class Import_Command extends WP_CLI_Command {
 				}
 
 				if ( empty( $files ) ) {
-					WP_CLI::warning( "No import files found in '$arg'." );
+					WP_CLI::warning( "No files found in the import dir '$arg'." );
 				}
 			} else {
 				if ( ! file_exists( $arg ) ) {

--- a/src/Import_Command.php
+++ b/src/Import_Command.php
@@ -71,7 +71,7 @@ class Import_Command extends WP_CLI_Command {
 				}
 			} else {
 				if ( ! file_exists( $arg ) ) {
-					WP_CLI::warning( " '$arg' doesn't exist." );
+					WP_CLI::warning( "'$arg' doesn't exist." );
 					continue;
 				}
 
@@ -80,7 +80,7 @@ class Import_Command extends WP_CLI_Command {
 					continue;
 				}
 
-				WP_CLI::warning( "Can't read '$file' file." );
+				WP_CLI::warning( "Can't read '$arg' file." );
 			}
 		}
 


### PR DESCRIPTION

Added additional check to bail if the file/files do not exist. By doing this a status code 1 will be available if the operation fails, as previously it did not exit with any status, due to the fact that $args was an empty array and it was never doing the foreach loop.